### PR TITLE
feat: Confgiure GitHub Actions to run pre-commit checks against PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: "Pre-commit CI"
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - uses: cachix/cachix-action@v12
+      with:
+        name: devenv
+    - name: Install devenv.sh
+      run: nix profile install tarball+https://install.devenv.sh/latest
+      shell: sh
+    - run: devenv ci
+    - run: devenv shell echo ok

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Devenv
 .devenv*
 devenv.local.nix
+/.direnv
 
 
 


### PR DESCRIPTION
This change configures GitHub Actions to run `devenv ci` as a required status check. For the moment that just means making sure that pre-commit hooks are passing before merging changes to `main`. 